### PR TITLE
Allow local files residing in file:/// to access socket server

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,8 +93,8 @@ function access(options) {
     // and that we don't answer with bullshit.
     //
     if (
-         !!~origin.indexOf('%')
-      || !parse(origin).protocol
+      !!~origin.indexOf('%')
+      || (origin === null && !parse(origin).protocol)
       || options.origins !== '*' && !~origins.indexOf(origin)
       || !~methods.indexOf(req.method)
       // @TODO header validation


### PR DESCRIPTION
This works because if a local file connects to a outside server (Even if it's localhost) it will send origin:null, previously that would fail but with this fix you can allow files that reside in file:/// to connect if options.origin = "*".
